### PR TITLE
Feature/15 directory migration

### DIFF
--- a/config/install/migrate_plus.migration.directories_facets.yml
+++ b/config/install/migrate_plus.migration.directories_facets.yml
@@ -1,0 +1,30 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - localgov_directories
+id: directories_facets
+migration_group: localgov_migration
+label: 'Directories facets type'
+source:
+  plugin: d8_entity
+  entity_type: taxonomy_term
+  bundle: directory_facet_option
+process:
+  bundle:
+    -
+      plugin: taxonomy_lookup
+      migration: directories_facets_type
+      source: field_parent_facet
+    -
+      plugin: extract
+      index:
+        - 0
+  title: name
+  langcode: langcode
+  status: status
+destination:
+  plugin: 'entity:localgov_directories_facets'
+migration_dependencies:
+  required:
+    - directories_facets_type

--- a/config/install/migrate_plus.migration.directories_facets_type.yml
+++ b/config/install/migrate_plus.migration.directories_facets_type.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - localgov_directories
+id: directories_facets_type
+migration_group: localgov_migration
+label: 'Directories facets type'
+source:
+  plugin: d8_entity
+  entity_type: taxonomy_term
+  bundle: directory_facet
+  constants:
+    entity_type: directories_facets_type
+process:
+  entity_type: 'constants/entity_type'
+  id:
+    plugin: machine_name
+    source: name
+  label: name
+  langcode: langcode
+  status: status
+destination:
+  plugin: 'entity:localgov_directories_facets_type'
+migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.directories_facets_type.yml
+++ b/config/install/migrate_plus.migration.directories_facets_type.yml
@@ -15,8 +15,12 @@ source:
 process:
   entity_type: 'constants/entity_type'
   id:
-    plugin: machine_name
-    source: name
+    -
+      plugin: machine_name
+      source: name
+    -
+      plugin: substr
+      length: 32
   label: name
   langcode: langcode
   status: status

--- a/config/install/migrate_plus.migration.directory_channel.yml
+++ b/config/install/migrate_plus.migration.directory_channel.yml
@@ -1,0 +1,49 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - localgov_directories
+id: directory_channel
+migration_group: localgov_migration
+label: 'Directory - channel'
+source:
+  plugin: d8_entity
+  entity_type: node
+  bundle: directory_listing
+  include_translations: false
+  constants:
+    # List of directory item content types to enable for channel.
+    channel_types:
+      - localgov_directories_page
+      - localgov_directories_venue
+process:
+  nid: nid
+  vid: vid
+  uuid: uuid
+  uid: uid
+  status: status
+  created: created
+  changed: changed
+  comment: comment
+  title: title
+  body:
+    plugin: sub_process
+    source: field_description
+    process:
+      value: value
+      format:
+        plugin: default_value
+        default_value: wysiwyg
+  localgov_directory_channel_types: 'constants/channel_types'
+  localgov_directory_facets_enable:
+    plugin: taxonomy_lookup
+    migration: directories_facets_type
+    source: field_directory_facets
+destination:
+  plugin: 'entity:node'
+  default_bundle: localgov_directory
+migration_dependencies:
+  required:
+    - directories_facets_type
+  optional:
+    - users

--- a/config/install/migrate_plus.migration.directory_page.yml
+++ b/config/install/migrate_plus.migration.directory_page.yml
@@ -1,0 +1,68 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - localgov_directories_page
+id: directory_page
+migration_group: localgov_migration
+label: 'Directory - page'
+source:
+  plugin: d8_entity
+  entity_type: node
+  bundle: directory_item
+  include_translations: false
+process:
+  # Skip if geofield is set as this should be a localgov_directories_venue.
+  location:
+    plugin: skip_on_not_empty
+    method: row
+    source: field_geofield
+  nid: nid
+  vid: vid
+  uuid: uuid
+  uid: uid
+  status: status
+  created: created
+  changed: changed
+  comment: comment
+  title: title
+  body:
+    -
+      plugin: sub_process
+      source: body
+      process:
+        value: value
+        format:
+          -
+            plugin: default_value
+            default_value: wysiwyg
+        summary: summary
+  localgov_directory_channels: field_directory
+  localgov_directory_facets_select:
+    plugin: taxonomy_lookup
+    migration: directories_facets
+    source: field_facet_options
+  localgov_directory_address:
+    plugin: sub_process
+    source: field_addressfield
+    process:
+      country_code:
+        plugin: default_value
+        default_value: GB
+      address_line1: street
+      locality: city
+      postal_code: postcode
+  localgov_directory_email: field_email_address
+  localgov_directory_phone: field_phone
+  localgov_directory_website:
+    plugin: fix_url
+    source: field_website_plain
+destination:
+  plugin: 'entity:node'
+  default_bundle: localgov_directories_page
+migration_dependencies:
+  required:
+    - directories_facets
+    - directory_channel
+  optional:
+    - users

--- a/config/install/migrate_plus.migration.directory_venue.yml
+++ b/config/install/migrate_plus.migration.directory_venue.yml
@@ -12,10 +12,10 @@ source:
   bundle: directory_item
   include_translations: false
 process:
-  # Skip if geofield is missing as this should be a localgov_directories_page.
+  # Skip if Geofield data is missing as this should be a localgov_directories_page.
   location:
-    plugin: skip_on_empty
-    method: row
+    plugin: skip_row_if_not_set
+    index: 0
     source: field_geofield
   nid: nid
   vid: vid
@@ -27,16 +27,14 @@ process:
   comment: comment
   title: title
   body:
-    -
-      plugin: sub_process
-      source: body
-      process:
-        value: value
-        format:
-          -
-            plugin: default_value
-            default_value: wysiwyg
-        summary: summary
+    plugin: sub_process
+    source: body
+    process:
+      value: value
+      format:
+        plugin: default_value
+        default_value: wysiwyg
+      summary: summary
   localgov_directory_channels: field_directory
   localgov_directory_facets_select:
     plugin: taxonomy_lookup
@@ -57,7 +55,14 @@ process:
   localgov_directory_website:
     plugin: fix_url
     source: field_website_plain
-  localgov_directory_notes: field_other_text
+  localgov_directory_notes:
+    plugin: sub_process
+    source: field_other_text
+    process:
+      value: value
+      format:
+        plugin: default_value
+        default_value: wysiwyg
   localgov_directory_opening_times:
     plugin: sub_process
     source: field_opening_times

--- a/config/install/migrate_plus.migration.directory_venue.yml
+++ b/config/install/migrate_plus.migration.directory_venue.yml
@@ -1,0 +1,75 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - localgov_directories_page
+id: directory_venue
+migration_group: localgov_migration
+label: 'Directory - venue'
+source:
+  plugin: d8_entity
+  entity_type: node
+  bundle: directory_item
+  include_translations: false
+process:
+  # Skip if geofield is missing as this should be a localgov_directories_page.
+  location:
+    plugin: skip_on_empty
+    method: row
+    source: field_geofield
+  nid: nid
+  vid: vid
+  uuid: uuid
+  uid: uid
+  status: status
+  created: created
+  changed: changed
+  comment: comment
+  title: title
+  body:
+    -
+      plugin: sub_process
+      source: body
+      process:
+        value: value
+        format:
+          -
+            plugin: default_value
+            default_value: wysiwyg
+        summary: summary
+  localgov_directory_channels: field_directory
+  localgov_directory_facets_select:
+    plugin: taxonomy_lookup
+    migration: directories_facets
+    source: field_facet_options
+  localgov_directory_address:
+    plugin: sub_process
+    source: field_addressfield
+    process:
+      country_code:
+        plugin: default_value
+        default_value: GB
+      address_line1: street
+      locality: city
+      postal_code: postcode
+  localgov_directory_email: field_email_address
+  localgov_directory_phone: field_phone
+  localgov_directory_website:
+    plugin: fix_url
+    source: field_website_plain
+  localgov_directory_notes: field_other_text
+  localgov_directory_opening_times: field_opening_times
+  localgov_location:
+    plugin: migration_lookup
+    migration: geo_address
+    source: nid
+destination:
+  plugin: 'entity:node'
+  default_bundle: localgov_directories_venue
+migration_dependencies:
+  required:
+    - directories_facets
+    - directory_channel
+    - geo_address
+  optional:
+    - users

--- a/config/install/migrate_plus.migration.directory_venue.yml
+++ b/config/install/migrate_plus.migration.directory_venue.yml
@@ -58,7 +58,14 @@ process:
     plugin: fix_url
     source: field_website_plain
   localgov_directory_notes: field_other_text
-  localgov_directory_opening_times: field_opening_times
+  localgov_directory_opening_times:
+    plugin: sub_process
+    source: field_opening_times
+    process:
+      value: value
+      format:
+        plugin: default_value
+        default_value: wysiwyg
   localgov_location:
     plugin: migration_lookup
     migration: geo_address

--- a/config/install/migrate_plus.migration.geo_address.yml
+++ b/config/install/migrate_plus.migration.geo_address.yml
@@ -11,11 +11,11 @@ source:
   entity_type: node
   bundle: directory_item
 process:
-  # Process directory entries with a Geofield in Geo entities.
+  # Process directory entries with Geofield data into LocalGov Geo address entities.
   location:
     -
-      plugin: skip_on_empty
-      method: row
+      plugin: skip_row_if_not_set
+      index: 0
       source: field_geofield
     -
       plugin: geo_location_to_field

--- a/config/install/migrate_plus.migration.geo_address.yml
+++ b/config/install/migrate_plus.migration.geo_address.yml
@@ -1,0 +1,47 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - localgov_directories_page
+id: geo_address
+migration_group: localgov_migration
+label: 'Geo - address'
+source:
+  plugin: d8_entity
+  entity_type: node
+  bundle: directory_item
+process:
+  # Process directory entries with a Geofield in Geo entities.
+  location:
+    -
+      plugin: skip_on_empty
+      method: row
+      source: field_geofield
+    -
+      plugin: geo_location_to_field
+  uid: uid
+  status:
+    - plugin: default_value
+      default_value: true
+  created: created
+  changed: changed
+  langcode: langcode
+  accessibility: field_accessibility
+  postal_address:
+    plugin: sub_process
+    source: field_addressfield
+    process:
+      country_code:
+        plugin: default_value
+        default_value: GB
+      address_line1: street
+      locality: city
+      postal_code: postcode
+destination:
+  plugin: 'entity:localgov_geo'
+  default_bundle: address
+migration_dependencies:
+  required:
+    - directory_channel
+  optional:
+    - users

--- a/config/install/migrate_plus.migration.service_sublanding.yml
+++ b/config/install/migrate_plus.migration.service_sublanding.yml
@@ -42,4 +42,3 @@ migration_dependencies:
     - users
     - service_landing
     - paragraph_topic_list_builder
-

--- a/localgov_legacy_migration.info.yml
+++ b/localgov_legacy_migration.info.yml
@@ -9,6 +9,9 @@ dependencies:
   - drupal:migrate_drupal_d8
   - drupal:migrate_tools
   # LocalGov Drupal
+  - localgov_directories:localgov_directories
+  - localgov_directories:localgov_directories_page
+  - localgov_directories:localgov_directories_venue
   - localgov_guides:localgov_guides
   - localgov_paragraphs:localgov_paragraphs
   - localgov_services:localgov_services_landing

--- a/localgov_legacy_migration.module
+++ b/localgov_legacy_migration.module
@@ -1,11 +1,6 @@
 <?php
 
-use Drupal\migrate\Plugin\MigrateSourceInterface;
-use Drupal\migrate\Plugin\MigrationInterface;
-use Drupal\migrate\Row;
-
-function localgov_legacy_migration_migrate_prepare_row(Row $row, MigrateSourceInterface $source, MigrationInterface $migration) {
-//  print $migration->id();
-//
-//  print_r($row->getSource());
-}
+/**
+ * @file
+ * LocalGov Drupal legacy migrations module file.
+ */

--- a/src/Plugin/migrate/destination/DirectoriesFacetsTypes.php
+++ b/src/Plugin/migrate/destination/DirectoriesFacetsTypes.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Drupal\localgov_legacy_migration\Plugin\migrate\destination;
+
+use Drupal\migrate\Plugin\migrate\destination\EntityConfigBase;
+
+/**
+ * Migrate into DirectoriesFacetsTypes config entities.
+ *
+ * @MigrateDestination(
+ *   id = "entity:localgov_directories_facets_type"
+ * )
+ */
+class DirectoriesFacetsTypes extends EntityConfigBase {
+
+}

--- a/src/Plugin/migrate/process/FixUrl.php
+++ b/src/Plugin/migrate/process/FixUrl.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Drupal\localgov_legacy_migration\Plugin\migrate\process;
+
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+
+/**
+ * Extract and fix URLs from a text field.
+ *
+ * @MigrateProcessPlugin(
+ *   id = "fix_url"
+ * )
+ *
+ * @code
+ * localgov_directory_website/uri:
+ *   plugin: fix_url
+ *   source: field_website_plain
+ * @endcode
+ */
+class FixUrl extends ProcessPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    if (isset($value['value'])) {
+      $url = $value['value'];
+
+      // This is very crude, but will ensure $url passes Drupal URL validation.
+      if (substr($url, 0, 1) === '/') {
+        $url = \Drupal::request()->getSchemeAndHttpHost() . $url;
+      }
+      elseif (!preg_match('/^(http|https):\/\//i', $url)) {
+        $url = 'http://' . $url;
+      }
+
+      return ['uri' => $url];
+    }
+    return NULL;
+  }
+
+}

--- a/src/Plugin/migrate/process/GeoLocationToField.php
+++ b/src/Plugin/migrate/process/GeoLocationToField.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\localgov_legacy_migration\Plugin\migrate\process;
+
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\Row;
+use Drupal\geofield\Plugin\migrate\process\GeofieldLatLon;
+
+/**
+ * Convert a Geolocation data to Geofield data.
+ *
+ * @MigrateProcessPlugin(
+ *   id = "geo_location_to_field"
+ * )
+ */
+class GeoLocationToField extends GeofieldLatLon {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    if (isset($value['lat']) and isset($value['lng'])) {
+      $lat = $value['lat'];
+      $lon = $value['lng'];
+      return $this->wktGenerator->WktBuildPoint([$lon, $lat]);
+    }
+
+    return NULL;
+  }
+
+}

--- a/src/Plugin/migrate/process/SkipOnNotEmpty.php
+++ b/src/Plugin/migrate/process/SkipOnNotEmpty.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Drupal\localgov_legacy_migration\Plugin\migrate\process;
+
+use Drupal\migrate\MigrateSkipProcessException;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\Row;
+use Drupal\migrate\MigrateSkipRowException;
+
+/**
+ * Skips the row or process if the given source value is set.
+ *
+ * Examples:
+ *
+ * @code
+ * process:
+ *   field_type_exists:
+ *     plugin: skip_on_not_empty
+ *     method: row
+ *     source: field_skip
+ *     message: 'Field field_skip is set'
+ * @endcode
+ * If 'field_skip' is set, the entire row is skipped and the 'message' is
+ * logged in the message table.
+ *
+ * @see \Drupal\migrate\Plugin\MigrateProcessInterface
+ *
+ * @MigrateProcessPlugin(
+ *   id = "skip_on_not_empty"
+ * )
+ */
+class SkipOnNotEmpty extends ProcessPluginBase {
+
+  /**
+   * Skips the current row when value is set.
+   *
+   * @param mixed $value
+   *   The input value.
+   * @param \Drupal\migrate\MigrateExecutableInterface $migrate_executable
+   *   The migration in which this process is being executed.
+   * @param \Drupal\migrate\Row $row
+   *   The row from the source to process.
+   * @param string $destination_property
+   *   The destination property currently worked on. This is only used together
+   *   with the $row above.
+   *
+   * @return mixed
+   *   The input value, $value, if it is not empty.
+   *
+   * @throws \Drupal\migrate\MigrateSkipRowException
+   *   Thrown if the source property is not set and the row should be skipped,
+   *   records with STATUS_IGNORED status in the map.
+   */
+  public function row($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    if ($value) {
+      $message = array_key_exists('message', $this->configuration) ? $this->configuration['message'] : '';
+      throw new MigrateSkipRowException($message);
+    }
+    return $value;
+  }
+
+  /**
+   * Stops processing the current property when value is set.
+   *
+   * @param mixed $value
+   *   The input value.
+   * @param \Drupal\migrate\MigrateExecutableInterface $migrate_executable
+   *   The migration in which this process is being executed.
+   * @param \Drupal\migrate\Row $row
+   *   The row from the source to process.
+   * @param string $destination_property
+   *   The destination property currently worked on. This is only used together
+   *   with the $row above.
+   *
+   * @return mixed
+   *   The input value, $value, if it is not empty.
+   *
+   * @throws \Drupal\migrate\MigrateSkipProcessException
+   *   Thrown if the source property is not set and rest of the process should
+   *   be skipped.
+   */
+  public function process($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    if ($value) {
+      $message = array_key_exists('message', $this->configuration) ? $this->configuration['message'] : '';
+      throw new MigrateSkipProcessException($message);
+    }
+    return $value;
+  }
+
+}

--- a/src/Plugin/migrate/process/TaxonomyLookup.php
+++ b/src/Plugin/migrate/process/TaxonomyLookup.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Drupal\localgov_legacy_migration\Plugin\migrate\process;
+
+use Drupal\Core\Database\Database;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+
+/**
+ * Lookup IDs from migrations using taxonomy term IDs.
+ *
+ * @MigrateProcessPlugin(
+ *   id = "taxonomy_lookup"
+ * )
+ *
+ * @code
+ * localgov_directory_facets_select::
+ *   plugin: taxonomy_lookup
+ *   migration: directories_facets
+ *   source: field_facet_options
+ * @endcode
+ */
+class TaxonomyLookup extends ProcessPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    if (isset($value['target_id'])) {
+
+      // Query migrate map table for destination ID using term ID.
+      $migration = $this->configuration['migration'];
+      $connection = Database::getConnection();
+      $query = $connection->select('migrate_map_' . $migration, 'm');
+      $query->addField('m', 'destid1');
+      $query->condition('m.sourceid1', $value['target_id']);
+      $result = $query->execute();
+
+      if ($id = $result->fetchField()) {
+        return $id;
+      }
+    }
+
+    return NULL;
+  }
+
+}


### PR DESCRIPTION
This is a first draft of a directory migration. There are a few bugs which I will spend time squashing tomorrow, but if you have time to test then please do and note any issues you find here.

The DirectoriesFacetsType and DirectoriesFacets entities are migrated from the directory_facet and directory_facet_option taxonomies.

Directory channels come from directory listings. Directory pages are directory items without any content in the geofield field. Directory venues are directory items with geofield content. This is run twice; first to create Geo entities and then to create the directory venues.

This has been deployed and run on the BHCC and Croydon testing sites. Example directories are:

- https://croydon.localgov.agile.coop/secondary-schools
- https://bhcc.localgov.agile.coop/public-toilets