### PR TITLE
Fix content moderation state on migrated content

### DIFF
--- a/config/install/migrate_plus.migration.campaigns_overview.yml
+++ b/config/install/migrate_plus.migration.campaigns_overview.yml
@@ -33,6 +33,7 @@ process:
   localgov_campaigns_colour_accent: field_select_colourway_accent
   localgov_campaigns_colour_grad: field_select_colorway
   localgov_campaigns_summary: 'body/summary'
+  moderation_state: moderation_state
 destination:
   plugin: 'entity:node'
   default_bundle: localgov_campaigns_overview

--- a/config/install/migrate_plus.migration.campaigns_overview.yml
+++ b/config/install/migrate_plus.migration.campaigns_overview.yml
@@ -33,7 +33,19 @@ process:
   localgov_campaigns_colour_accent: field_select_colourway_accent
   localgov_campaigns_colour_grad: field_select_colorway
   localgov_campaigns_summary: 'body/summary'
+  # Workflow content moderation state.
   moderation_state: moderation_state
+  # Alternative Workflow content moderation state.
+  # Uncomment the following (and comment out the above) if the source site did
+  # not have workflow / content moderation switched on for this content type
+  # moderation_state:
+  #   -
+  #     plugin: static_map
+  #     source: status
+  #     default_value: draft
+  #     map:
+  #       '0': draft
+  #       '1': published
 destination:
   plugin: 'entity:node'
   default_bundle: localgov_campaigns_overview

--- a/config/install/migrate_plus.migration.campaigns_page.yml
+++ b/config/install/migrate_plus.migration.campaigns_page.yml
@@ -27,6 +27,7 @@ process:
     source: field_page_builder_advanced
   localgov_campaigns_summary: 'body/summary'
   localgov_campaigns_topic: field_topic_term
+  moderation_state: moderation_state
 destination:
   plugin: 'entity:node'
   default_bundle: localgov_campaigns_page

--- a/config/install/migrate_plus.migration.campaigns_page.yml
+++ b/config/install/migrate_plus.migration.campaigns_page.yml
@@ -27,7 +27,19 @@ process:
     source: field_page_builder_advanced
   localgov_campaigns_summary: 'body/summary'
   localgov_campaigns_topic: field_topic_term
+  # Workflow content moderation state.
   moderation_state: moderation_state
+  # Alternative Workflow content moderation state.
+  # Uncomment the following (and comment out the above) if the source site did
+  # not have workflow / content moderation switched on for this content type
+  # moderation_state:
+  #   -
+  #     plugin: static_map
+  #     source: status
+  #     default_value: draft
+  #     map:
+  #       '0': draft
+  #       '1': published
 destination:
   plugin: 'entity:node'
   default_bundle: localgov_campaigns_page

--- a/config/install/migrate_plus.migration.directory_channel.yml
+++ b/config/install/migrate_plus.migration.directory_channel.yml
@@ -44,7 +44,19 @@ process:
     plugin: default_value
     default_value: 0
   'path/alias': alias
+  # Workflow content moderation state.
   moderation_state: moderation_state
+  # Alternative Workflow content moderation state.
+  # Uncomment the following (and comment out the above) if the source site did
+  # not have workflow / content moderation switched on for this content type
+  # moderation_state:
+  #   -
+  #     plugin: static_map
+  #     source: status
+  #     default_value: draft
+  #     map:
+  #       '0': draft
+  #       '1': published
 destination:
   plugin: 'entity:node'
   default_bundle: localgov_directory

--- a/config/install/migrate_plus.migration.directory_channel.yml
+++ b/config/install/migrate_plus.migration.directory_channel.yml
@@ -44,6 +44,7 @@ process:
     plugin: default_value
     default_value: 0
   'path/alias': alias
+  moderation_state: moderation_state
 destination:
   plugin: 'entity:node'
   default_bundle: localgov_directory

--- a/config/install/migrate_plus.migration.directory_page.yml
+++ b/config/install/migrate_plus.migration.directory_page.yml
@@ -62,6 +62,7 @@ process:
     plugin: default_value
     default_value: 0
   'path/alias': alias
+  moderation_state: moderation_state
 destination:
   plugin: 'entity:node'
   default_bundle: localgov_directories_page

--- a/config/install/migrate_plus.migration.directory_page.yml
+++ b/config/install/migrate_plus.migration.directory_page.yml
@@ -62,7 +62,19 @@ process:
     plugin: default_value
     default_value: 0
   'path/alias': alias
+  # Workflow content moderation state.
   moderation_state: moderation_state
+  # Alternative Workflow content moderation state.
+  # Uncomment the following (and comment out the above) if the source site did
+  # not have workflow / content moderation switched on for this content type
+  # moderation_state:
+  #   -
+  #     plugin: static_map
+  #     source: status
+  #     default_value: draft
+  #     map:
+  #       '0': draft
+  #       '1': published
 destination:
   plugin: 'entity:node'
   default_bundle: localgov_directories_page

--- a/config/install/migrate_plus.migration.directory_venue.yml
+++ b/config/install/migrate_plus.migration.directory_venue.yml
@@ -80,7 +80,19 @@ process:
     plugin: default_value
     default_value: 0
   'path/alias': alias
+  # Workflow content moderation state.
   moderation_state: moderation_state
+  # Alternative Workflow content moderation state.
+  # Uncomment the following (and comment out the above) if the source site did
+  # not have workflow / content moderation switched on for this content type
+  # moderation_state:
+  #   -
+  #     plugin: static_map
+  #     source: status
+  #     default_value: draft
+  #     map:
+  #       '0': draft
+  #       '1': published
 destination:
   plugin: 'entity:node'
   default_bundle: localgov_directories_venue

--- a/config/install/migrate_plus.migration.directory_venue.yml
+++ b/config/install/migrate_plus.migration.directory_venue.yml
@@ -80,6 +80,7 @@ process:
     plugin: default_value
     default_value: 0
   'path/alias': alias
+  moderation_state: moderation_state
 destination:
   plugin: 'entity:node'
   default_bundle: localgov_directories_venue

--- a/config/install/migrate_plus.migration.guides_overview.yml
+++ b/config/install/migrate_plus.migration.guides_overview.yml
@@ -46,7 +46,19 @@ process:
     plugin: default_value
     default_value: 0
   'path/alias': alias
+  # Workflow content moderation state.
   moderation_state: moderation_state
+  # Alternative Workflow content moderation state.
+  # Uncomment the following (and comment out the above) if the source site did
+  # not have workflow / content moderation switched on for this content type
+  # moderation_state:
+  #   -
+  #     plugin: static_map
+  #     source: status
+  #     default_value: draft
+  #     map:
+  #       '0': draft
+  #       '1': published
 destination:
   plugin: 'entity:node'
   default_bundle: localgov_guides_overview

--- a/config/install/migrate_plus.migration.guides_overview.yml
+++ b/config/install/migrate_plus.migration.guides_overview.yml
@@ -46,6 +46,7 @@ process:
     plugin: default_value
     default_value: 0
   'path/alias': alias
+  moderation_state: moderation_state
 destination:
   plugin: 'entity:node'
   default_bundle: localgov_guides_overview

--- a/config/install/migrate_plus.migration.guides_page.yml
+++ b/config/install/migrate_plus.migration.guides_page.yml
@@ -40,7 +40,19 @@ process:
     plugin: default_value
     default_value: 0
   'path/alias': alias
+  # Workflow content moderation state.
   moderation_state: moderation_state
+  # Alternative Workflow content moderation state.
+  # Uncomment the following (and comment out the above) if the source site did
+  # not have workflow / content moderation switched on for this content type
+  # moderation_state:
+  #   -
+  #     plugin: static_map
+  #     source: status
+  #     default_value: draft
+  #     map:
+  #       '0': draft
+  #       '1': published
 destination:
   plugin: 'entity:node'
   default_bundle: localgov_guides_page

--- a/config/install/migrate_plus.migration.guides_page.yml
+++ b/config/install/migrate_plus.migration.guides_page.yml
@@ -40,6 +40,7 @@ process:
     plugin: default_value
     default_value: 0
   'path/alias': alias
+  moderation_state: moderation_state
 destination:
   plugin: 'entity:node'
   default_bundle: localgov_guides_page

--- a/config/install/migrate_plus.migration.service_landing.yml
+++ b/config/install/migrate_plus.migration.service_landing.yml
@@ -51,7 +51,19 @@ process:
     plugin: default_value
     default_value: 0
   'path/alias': alias
+  # Workflow content moderation state.
   moderation_state: moderation_state
+  # Alternative Workflow content moderation state.
+  # Uncomment the following (and comment out the above) if the source site did
+  # not have workflow / content moderation switched on for this content type
+  # moderation_state:
+  #   -
+  #     plugin: static_map
+  #     source: status
+  #     default_value: draft
+  #     map:
+  #       '0': draft
+  #       '1': published
 destination:
   plugin: 'entity:node'
   default_bundle: localgov_services_landing

--- a/config/install/migrate_plus.migration.service_landing.yml
+++ b/config/install/migrate_plus.migration.service_landing.yml
@@ -51,6 +51,7 @@ process:
     plugin: default_value
     default_value: 0
   'path/alias': alias
+  moderation_state: moderation_state
 destination:
   plugin: 'entity:node'
   default_bundle: localgov_services_landing

--- a/config/install/migrate_plus.migration.service_page.yml
+++ b/config/install/migrate_plus.migration.service_page.yml
@@ -45,6 +45,7 @@ process:
     plugin: default_value
     default_value: 0
   'path/alias': alias
+  moderation_state: moderation_state
 destination:
   plugin: 'entity:node'
   default_bundle: localgov_services_page

--- a/config/install/migrate_plus.migration.service_page.yml
+++ b/config/install/migrate_plus.migration.service_page.yml
@@ -45,7 +45,19 @@ process:
     plugin: default_value
     default_value: 0
   'path/alias': alias
+  # Workflow content moderation state.
   moderation_state: moderation_state
+  # Alternative Workflow content moderation state.
+  # Uncomment the following (and comment out the above) if the source site did
+  # not have workflow / content moderation switched on for this content type
+  # moderation_state:
+  #   -
+  #     plugin: static_map
+  #     source: status
+  #     default_value: draft
+  #     map:
+  #       '0': draft
+  #       '1': published
 destination:
   plugin: 'entity:node'
   default_bundle: localgov_services_page

--- a/config/install/migrate_plus.migration.service_status.yml
+++ b/config/install/migrate_plus.migration.service_status.yml
@@ -39,6 +39,7 @@ process:
     plugin: default_value
     default_value: 0
   'path/alias': alias
+  moderation_state: moderation_state
 destination:
   plugin: 'entity:node'
   default_bundle: localgov_services_status

--- a/config/install/migrate_plus.migration.service_status.yml
+++ b/config/install/migrate_plus.migration.service_status.yml
@@ -39,7 +39,19 @@ process:
     plugin: default_value
     default_value: 0
   'path/alias': alias
+  # Workflow content moderation state.
   moderation_state: moderation_state
+  # Alternative Workflow content moderation state.
+  # Uncomment the following (and comment out the above) if the source site did
+  # not have workflow / content moderation switched on for this content type
+  # moderation_state:
+  #   -
+  #     plugin: static_map
+  #     source: status
+  #     default_value: draft
+  #     map:
+  #       '0': draft
+  #       '1': published
 destination:
   plugin: 'entity:node'
   default_bundle: localgov_services_status

--- a/config/install/migrate_plus.migration.service_sublanding.yml
+++ b/config/install/migrate_plus.migration.service_sublanding.yml
@@ -39,7 +39,19 @@ process:
     plugin: default_value
     default_value: 0
   'path/alias': alias
+  # Workflow content moderation state.
   moderation_state: moderation_state
+  # Alternative Workflow content moderation state.
+  # Uncomment the following (and comment out the above) if the source site did
+  # not have workflow / content moderation switched on for this content type
+  # moderation_state:
+  #   -
+  #     plugin: static_map
+  #     source: status
+  #     default_value: draft
+  #     map:
+  #       '0': draft
+  #       '1': published
 destination:
   plugin: 'entity:node'
   default_bundle: localgov_services_sublanding

--- a/config/install/migrate_plus.migration.service_sublanding.yml
+++ b/config/install/migrate_plus.migration.service_sublanding.yml
@@ -39,6 +39,7 @@ process:
     plugin: default_value
     default_value: 0
   'path/alias': alias
+  moderation_state: moderation_state
 destination:
   plugin: 'entity:node'
   default_bundle: localgov_services_sublanding

--- a/config/install/migrate_plus.migration.step_by_step_overview.yml
+++ b/config/install/migrate_plus.migration.step_by_step_overview.yml
@@ -46,7 +46,19 @@ process:
     plugin: default_value
     default_value: 0
   'path/alias': alias
+  # Workflow content moderation state.
   moderation_state: moderation_state
+  # Alternative Workflow content moderation state.
+  # Uncomment the following (and comment out the above) if the source site did
+  # not have workflow / content moderation switched on for this content type
+  # moderation_state:
+  #   -
+  #     plugin: static_map
+  #     source: status
+  #     default_value: draft
+  #     map:
+  #       '0': draft
+  #       '1': published
 destination:
   plugin: 'entity:node'
   default_bundle: localgov_step_by_step_overview

--- a/config/install/migrate_plus.migration.step_by_step_overview.yml
+++ b/config/install/migrate_plus.migration.step_by_step_overview.yml
@@ -46,6 +46,7 @@ process:
     plugin: default_value
     default_value: 0
   'path/alias': alias
+  moderation_state: moderation_state
 destination:
   plugin: 'entity:node'
   default_bundle: localgov_step_by_step_overview

--- a/config/install/migrate_plus.migration.step_by_step_page.yml
+++ b/config/install/migrate_plus.migration.step_by_step_page.yml
@@ -40,6 +40,7 @@ process:
     plugin: default_value
     default_value: 0
   'path/alias': alias
+  moderation_state: moderation_state
 destination:
   plugin: 'entity:node'
   default_bundle: localgov_step_by_step_page

--- a/config/install/migrate_plus.migration.step_by_step_page.yml
+++ b/config/install/migrate_plus.migration.step_by_step_page.yml
@@ -40,7 +40,19 @@ process:
     plugin: default_value
     default_value: 0
   'path/alias': alias
+  # Workflow content moderation state.
   moderation_state: moderation_state
+  # Alternative Workflow content moderation state.
+  # Uncomment the following (and comment out the above) if the source site did
+  # not have workflow / content moderation switched on for this content type
+  # moderation_state:
+  #   -
+  #     plugin: static_map
+  #     source: status
+  #     default_value: draft
+  #     map:
+  #       '0': draft
+  #       '1': published
 destination:
   plugin: 'entity:node'
   default_bundle: localgov_step_by_step_page


### PR DESCRIPTION
fix #2.

Adds `moderation_state: moderation_state` to the content migration, 
add a commented out version of the alternative method.