### PR TITLE
Media migration: Migrate existing Media entities

### DIFF
--- a/config/install/migrate_plus.migration.media_document.yml
+++ b/config/install/migrate_plus.migration.media_document.yml
@@ -19,6 +19,19 @@ process:
       - 'image/jpeg'
       - 'image/png'
     source: filemime
+  # Skip if a Media document already exists for this file.
+  skip_if_media_exists:
+    -
+      plugin: entity_lookup
+      entity_type: media
+      bundle: document
+      bundle_key: bundle
+      value_key: field_media_document
+      source: fid
+      ignore_case: true
+    -
+      plugin: skip_on_not_empty
+      method: row
   # Skip if file hasn't been migrated.
   id:
     -
@@ -40,4 +53,5 @@ destination:
   default_bundle: document
 migration_dependencies:
   required:
+    - media_existing
     - files

--- a/config/install/migrate_plus.migration.media_existing.yml
+++ b/config/install/migrate_plus.migration.media_existing.yml
@@ -18,7 +18,14 @@ process:
   name: name
   created: created
   changed: changed
-  bundle: bundle
+  bundle:
+    source: bundle
+    # Only process Media entities provided by the localgov_media module.
+    plugin: static_map
+    map:
+      document: document
+      image: image
+      remote_video: remote_video
   thumbnail: thumbnail
   field_media_document: field_media_document
   field_media_image: field_media_image

--- a/config/install/migrate_plus.migration.media_existing.yml
+++ b/config/install/migrate_plus.migration.media_existing.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - localgov_media
+id: media_existing
+migration_group: localgov_migration
+label: 'Media - existing'
+source:
+  plugin: d8_entity
+  entity_type: media
+process:
+  mid: mid
+  vid: vid
+  status: status
+  uid: uid
+  uuid: uuid
+  name: name
+  created: created
+  changed: changed
+  bundle: bundle
+  thumbnail: thumbnail
+  field_media_document: field_media_document
+  field_media_image: field_media_image
+destination:
+  plugin: 'entity:media'
+migration_dependencies:
+  required:
+    - files

--- a/config/install/migrate_plus.migration.media_image.yml
+++ b/config/install/migrate_plus.migration.media_image.yml
@@ -20,6 +20,19 @@ process:
       - 'image/jpeg'
       - 'image/png'
     source: filemime
+  # Skip if a Media image already exists for this file.
+  skip_if_media_exists:
+    -
+      plugin: entity_lookup
+      entity_type: media
+      bundle: image
+      bundle_key: bundle
+      value_key: field_media_image
+      source: fid
+      ignore_case: true
+    -
+      plugin: skip_on_not_empty
+      method: row
   # Skip if file hasn't been migrated.
   id:
     -
@@ -41,4 +54,5 @@ destination:
   default_bundle: image
 migration_dependencies:
   required:
+    - media_existing
     - files


### PR DESCRIPTION
- Migrate all existing Media entities.
- When creating parent Media entities for all **existing** File entities, ignore those files who already have a parent Media entity.

This is a continuation of the previous File and Media migration work: #20 .  Here we implement Steve's final suggestion from #20 :
> An alternative solution would be to migrate existing media entities and then migrate the files into media entities. You would then need to add a check to see if a file was already referenced by a media entity as otherwise there would be multiple media entities for a single file.