### PR TITLE
New Migration groups

### DIFF
--- a/config/install/migrate_plus.migration.campaigns_overview.yml
+++ b/config/install/migrate_plus.migration.campaigns_overview.yml
@@ -4,7 +4,7 @@ dependencies:
   module:
     - localgov_guides
 id: campaigns_overview
-migration_group: localgov_migration
+migration_group: localgov_campaigns
 label: 'Campaigns - overview'
 source:
   plugin: d8_entity

--- a/config/install/migrate_plus.migration.campaigns_page.yml
+++ b/config/install/migrate_plus.migration.campaigns_page.yml
@@ -4,7 +4,7 @@ dependencies:
   module:
     - localgov_guides
 id: campaigns_page
-migration_group: localgov_migration
+migration_group: localgov_campaigns
 label: 'Campaigns - page'
 source:
   plugin: d8_entity

--- a/config/install/migrate_plus.migration.directories_facets.yml
+++ b/config/install/migrate_plus.migration.directories_facets.yml
@@ -4,7 +4,7 @@ dependencies:
   module:
     - localgov_directories
 id: directories_facets
-migration_group: localgov_migration
+migration_group: localgov_directories
 label: 'Directories facets type'
 source:
   plugin: d8_entity

--- a/config/install/migrate_plus.migration.directories_facets_type.yml
+++ b/config/install/migrate_plus.migration.directories_facets_type.yml
@@ -4,7 +4,7 @@ dependencies:
   module:
     - localgov_directories
 id: directories_facets_type
-migration_group: localgov_migration
+migration_group: localgov_directories
 label: 'Directories facets type'
 source:
   plugin: d8_entity

--- a/config/install/migrate_plus.migration.directory_channel.yml
+++ b/config/install/migrate_plus.migration.directory_channel.yml
@@ -4,7 +4,7 @@ dependencies:
   module:
     - localgov_directories
 id: directory_channel
-migration_group: localgov_migration
+migration_group: localgov_directories
 label: 'Directory - channel'
 source:
   plugin: d8_entity_path

--- a/config/install/migrate_plus.migration.directory_page.yml
+++ b/config/install/migrate_plus.migration.directory_page.yml
@@ -4,7 +4,7 @@ dependencies:
   module:
     - localgov_directories_page
 id: directory_page
-migration_group: localgov_migration
+migration_group: localgov_directories
 label: 'Directory - page'
 source:
   plugin: d8_entity_path

--- a/config/install/migrate_plus.migration.directory_venue.yml
+++ b/config/install/migrate_plus.migration.directory_venue.yml
@@ -4,7 +4,7 @@ dependencies:
   module:
     - localgov_directories_page
 id: directory_venue
-migration_group: localgov_migration
+migration_group: localgov_directories
 label: 'Directory - venue'
 source:
   plugin: d8_entity_path

--- a/config/install/migrate_plus.migration.files.yml
+++ b/config/install/migrate_plus.migration.files.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: files
-migration_group: localgov_migration
+migration_group: localgov_media
 label: 'File entities'
 source:
   plugin: d8_entity

--- a/config/install/migrate_plus.migration.geo_address.yml
+++ b/config/install/migrate_plus.migration.geo_address.yml
@@ -4,7 +4,7 @@ dependencies:
   module:
     - localgov_directories_page
 id: geo_address
-migration_group: localgov_migration
+migration_group: localgov_directories
 label: 'Geo - address'
 source:
   plugin: d8_entity

--- a/config/install/migrate_plus.migration.guides_overview.yml
+++ b/config/install/migrate_plus.migration.guides_overview.yml
@@ -4,7 +4,7 @@ dependencies:
   module:
     - localgov_guides
 id: guides_overview
-migration_group: localgov_migration
+migration_group: localgov_guides
 label: 'Guides - overview'
 source:
   plugin: d8_entity_path

--- a/config/install/migrate_plus.migration.guides_page.yml
+++ b/config/install/migrate_plus.migration.guides_page.yml
@@ -4,7 +4,7 @@ dependencies:
   module:
     - localgov_guides
 id: guides_page
-migration_group: localgov_migration
+migration_group: localgov_guides
 label: 'Guides - page'
 source:
   plugin: d8_entity_path

--- a/config/install/migrate_plus.migration.media_document.yml
+++ b/config/install/migrate_plus.migration.media_document.yml
@@ -4,7 +4,7 @@ dependencies:
   module:
     - localgov_media
 id: media_document
-migration_group: localgov_migration
+migration_group: localgov_media
 label: 'Media - documents'
 source:
   plugin: d8_entity

--- a/config/install/migrate_plus.migration.media_image.yml
+++ b/config/install/migrate_plus.migration.media_image.yml
@@ -4,7 +4,7 @@ dependencies:
   module:
     - localgov_media
 id: media_image
-migration_group: localgov_migration
+migration_group: localgov_media
 label: 'Media - images'
 source:
   plugin: d8_entity

--- a/config/install/migrate_plus.migration.paragraph_box_link.yml
+++ b/config/install/migrate_plus.migration.paragraph_box_link.yml
@@ -1,10 +1,7 @@
 langcode: en
 status: true
-dependencies:
-  module:
-    - localgov_campaigns_paragraphs
 id: paragraph_box_link
-migration_group: localgov_migration
+migration_group: localgov_paragraphs
 label: 'Paragraph - box link'
 source:
   plugin: d8_entity

--- a/config/install/migrate_plus.migration.paragraph_call_out_box.yml
+++ b/config/install/migrate_plus.migration.paragraph_call_out_box.yml
@@ -1,10 +1,7 @@
 langcode: en
 status: true
-dependencies:
-  module:
-    - localgov_campaigns_paragraphs
 id: paragraph_call_out_box
-migration_group: localgov_migration
+migration_group: localgov_paragraphs
 label: 'Paragraph - call out box'
 source:
   plugin: d8_entity

--- a/config/install/migrate_plus.migration.paragraph_contact.yml
+++ b/config/install/migrate_plus.migration.paragraph_contact.yml
@@ -1,10 +1,7 @@
 langcode: en
 status: true
-dependencies:
-  module:
-    - localgov_paragraphs
 id: paragraph_contact
-migration_group: localgov_migration
+migration_group: localgov_paragraphs
 label: 'Paragraph - Contact'
 source:
   plugin: d8_entity

--- a/config/install/migrate_plus.migration.paragraph_fact_box.yml
+++ b/config/install/migrate_plus.migration.paragraph_fact_box.yml
@@ -1,10 +1,7 @@
 langcode: en
 status: true
-dependencies:
-  module:
-    - localgov_campaigns_paragraphs
 id: paragraph_fact_box
-migration_group: localgov_migration
+migration_group: localgov_paragraphs
 label: 'Paragraph - fact box'
 source:
   plugin: d8_entity

--- a/config/install/migrate_plus.migration.paragraph_link.yml
+++ b/config/install/migrate_plus.migration.paragraph_link.yml
@@ -1,10 +1,7 @@
 langcode: en
 status: true
-dependencies:
-  module:
-    - localgov_campaigns_paragraphs
 id: paragraph_link
-migration_group: localgov_migration
+migration_group: localgov_paragraphs
 label: 'Paragraph - link'
 source:
   plugin: d8_entity

--- a/config/install/migrate_plus.migration.paragraph_link_and_summary.yml
+++ b/config/install/migrate_plus.migration.paragraph_link_and_summary.yml
@@ -1,10 +1,7 @@
 langcode: en
 status: true
-dependencies:
-  module:
-    - localgov_campaigns_paragraphs
 id: paragraph_link_and_summary
-migration_group: localgov_migration
+migration_group: localgov_paragraphs
 label: 'Paragraph - link and summary'
 source:
   plugin: d8_entity

--- a/config/install/migrate_plus.migration.paragraph_quote.yml
+++ b/config/install/migrate_plus.migration.paragraph_quote.yml
@@ -1,10 +1,7 @@
 langcode: en
 status: true
-dependencies:
-  module:
-    - localgov_campaigns_paragraphs
 id: paragraph_quote
-migration_group: localgov_migration
+migration_group: localgov_paragraphs
 label: 'Paragraph - call out box'
 source:
   plugin: d8_entity

--- a/config/install/migrate_plus.migration.paragraph_text.yml
+++ b/config/install/migrate_plus.migration.paragraph_text.yml
@@ -1,10 +1,7 @@
 langcode: en
 status: true
-dependencies:
-  module:
-    - localgov_campaigns_paragraphs
 id: paragraph_text
-migration_group: localgov_migration
+migration_group: localgov_paragraphs
 label: 'Paragraph - call out box'
 source:
   plugin: d8_entity

--- a/config/install/migrate_plus.migration.paragraph_topic_list_builder.yml
+++ b/config/install/migrate_plus.migration.paragraph_topic_list_builder.yml
@@ -4,7 +4,7 @@ dependencies:
   module:
     - localgov_services_sublanding
 id: paragraph_topic_list_builder
-migration_group: localgov_migration
+migration_group: localgov_paragraphs
 label: 'Topic list builder'
 source:
   plugin: d8_entity

--- a/config/install/migrate_plus.migration.paragraphs_library_item.yml
+++ b/config/install/migrate_plus.migration.paragraphs_library_item.yml
@@ -1,8 +1,11 @@
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  enforced:
+    module:
+      - paragraphs_library
 id: paragraphs_library_item
-migration_group: localgov_migration
+migration_group: localgov_paragraphs
 label: 'Page components'
 source:
   plugin: d8_entity

--- a/config/install/migrate_plus.migration.service_landing.yml
+++ b/config/install/migrate_plus.migration.service_landing.yml
@@ -4,7 +4,7 @@ dependencies:
   module:
     - localgov_services_landing
 id: service_landing
-migration_group: localgov_migration
+migration_group: localgov_services
 label: 'Services - landing page'
 source:
   plugin: d8_entity_path

--- a/config/install/migrate_plus.migration.service_page.yml
+++ b/config/install/migrate_plus.migration.service_page.yml
@@ -4,7 +4,7 @@ dependencies:
   module:
     - localgov_services_page
 id: service_page
-migration_group: localgov_migration
+migration_group: localgov_services
 label: 'Services - page'
 source:
   plugin: d8_entity_path

--- a/config/install/migrate_plus.migration.service_status.yml
+++ b/config/install/migrate_plus.migration.service_status.yml
@@ -4,7 +4,7 @@ dependencies:
   module:
     - localgov_services_status
 id: service_status
-migration_group: localgov_migration
+migration_group: localgov_services
 label: 'Service - status page'
 source:
   plugin: d8_entity_path

--- a/config/install/migrate_plus.migration.service_sublanding.yml
+++ b/config/install/migrate_plus.migration.service_sublanding.yml
@@ -4,7 +4,7 @@ dependencies:
   module:
     - localgov_services_sublanding
 id: service_sublanding
-migration_group: localgov_migration
+migration_group: localgov_services
 label: 'Service - sub-landing page'
 source:
   plugin: d8_entity_path

--- a/config/install/migrate_plus.migration.step_by_step_overview.yml
+++ b/config/install/migrate_plus.migration.step_by_step_overview.yml
@@ -4,7 +4,7 @@ dependencies:
   module:
     - localgov_step_by_step
 id: step_by_step_overview
-migration_group: localgov_migration
+migration_group: localgov_step_by_step
 label: 'Step by step - overview'
 source:
   plugin: d8_entity_path

--- a/config/install/migrate_plus.migration.step_by_step_page.yml
+++ b/config/install/migrate_plus.migration.step_by_step_page.yml
@@ -4,7 +4,7 @@ dependencies:
   module:
     - localgov_step_by_step
 id: step_by_step_page
-migration_group: localgov_migration
+migration_group: localgov_step_by_step
 label: 'Step by step - page'
 source:
   plugin: d8_entity_path

--- a/config/install/migrate_plus.migration_group.localgov_campaigns.yml
+++ b/config/install/migrate_plus.migration_group.localgov_campaigns.yml
@@ -1,0 +1,22 @@
+id: localgov_campaigns
+
+label: 'LocalGov Campaigns'
+
+description: 'Targets Campaign overview and Campaign page content types.'
+
+source_type: 'Drupal 8 site'
+
+shared_configuration:
+  dependencies:
+    enforced:
+      module:
+      - localgov_campaigns
+      - localgov_legacy_migration
+  source:
+    key: migration
+
+dependencies:
+  enforced:
+    module:
+      - localgov_campaigns
+      - localgov_legacy_migration

--- a/config/install/migrate_plus.migration_group.localgov_directories.yml
+++ b/config/install/migrate_plus.migration_group.localgov_directories.yml
@@ -1,0 +1,22 @@
+id: localgov_directories
+
+label: 'LocalGov Directories'
+
+description: 'Targets Directory related entities.'
+
+source_type: 'Drupal 8 site'
+
+shared_configuration:
+  dependencies:
+    enforced:
+      module:
+      - localgov_directories
+      - localgov_legacy_migration
+  source:
+    key: migration
+
+dependencies:
+  enforced:
+    module:
+      - localgov_directories
+      - localgov_legacy_migration

--- a/config/install/migrate_plus.migration_group.localgov_guides.yml
+++ b/config/install/migrate_plus.migration_group.localgov_guides.yml
@@ -1,0 +1,22 @@
+id: localgov_guides
+
+label: 'LocalGov Guides'
+
+description: 'Targets Guide overview and Guide page content types.'
+
+source_type: 'Drupal 8 site'
+
+shared_configuration:
+  dependencies:
+    enforced:
+      module:
+      - localgov_guides
+      - localgov_legacy_migration
+  source:
+    key: migration
+
+dependencies:
+  enforced:
+    module:
+      - localgov_guides
+      - localgov_legacy_migration

--- a/config/install/migrate_plus.migration_group.localgov_media.yml
+++ b/config/install/migrate_plus.migration_group.localgov_media.yml
@@ -1,0 +1,22 @@
+id: localgov_media
+
+label: 'LocalGov Media'
+
+description: 'Targets Media related entities.'
+
+source_type: 'Drupal 8 site'
+
+shared_configuration:
+  dependencies:
+    enforced:
+      module:
+      - localgov_media
+      - localgov_legacy_migration
+  source:
+    key: migration
+
+dependencies:
+  enforced:
+    module:
+      - localgov_media
+      - localgov_legacy_migration

--- a/config/install/migrate_plus.migration_group.localgov_paragraphs.yml
+++ b/config/install/migrate_plus.migration_group.localgov_paragraphs.yml
@@ -1,0 +1,24 @@
+id: localgov_paragraphs
+
+label: 'LocalGov Paragraphs'
+
+description: 'Targets Paragraph related entities.'
+
+source_type: 'Drupal 8 site'
+
+shared_configuration:
+  dependencies:
+    enforced:
+      module:
+      - localgov_campaigns_paragraphs
+      - localgov_paragraphs
+      - localgov_legacy_migration
+  source:
+    key: migration
+
+dependencies:
+  enforced:
+    module:
+      - localgov_campaigns_paragraphs
+      - localgov_paragraphs
+      - localgov_legacy_migration

--- a/config/install/migrate_plus.migration_group.localgov_services.yml
+++ b/config/install/migrate_plus.migration_group.localgov_services.yml
@@ -1,0 +1,22 @@
+id: localgov_services
+
+label: 'LocalGov Services'
+
+description: 'Targets Service related content types.'
+
+source_type: 'Drupal 8 site'
+
+shared_configuration:
+  dependencies:
+    enforced:
+      module:
+      - localgov_services
+      - localgov_legacy_migration
+  source:
+    key: migration
+
+dependencies:
+  enforced:
+    module:
+      - localgov_services
+      - localgov_legacy_migration

--- a/config/install/migrate_plus.migration_group.localgov_step_by_step.yml
+++ b/config/install/migrate_plus.migration_group.localgov_step_by_step.yml
@@ -1,0 +1,22 @@
+id: localgov_step_by_step
+
+label: 'LocalGov Step-by-step'
+
+description: 'Targets Step-by-step overview and Step-by-step page content types.'
+
+source_type: 'Drupal 8 site'
+
+shared_configuration:
+  dependencies:
+    enforced:
+      module:
+      - localgov_step_by_step
+      - localgov_legacy_migration
+  source:
+    key: migration
+
+dependencies:
+  enforced:
+    module:
+      - localgov_step_by_step
+      - localgov_legacy_migration


### PR DESCRIPTION
New group names reflect the LocalGov module structure.  For example, all
Campaign related content types have become part of the localgov_campaigns
Migration group.

Closes #24 