### PR TITLE
Incremental migration

### DIFF
--- a/config/install/migrate_plus.migration.campaigns_overview.yml
+++ b/config/install/migrate_plus.migration.campaigns_overview.yml
@@ -11,9 +11,9 @@ source:
   entity_type: node
   bundle: campaign_overview
   include_translations: false
+  track_changes: true
 process:
   nid: nid
-  vid: vid
   uuid: uuid
   uid: uid
   status: status

--- a/config/install/migrate_plus.migration.campaigns_page.yml
+++ b/config/install/migrate_plus.migration.campaigns_page.yml
@@ -11,9 +11,9 @@ source:
   entity_type: node
   bundle: campaign_page
   include_translations: false
+  track_changes: true
 process:
   nid: nid
-  vid: vid
   uuid: uuid
   uid: uid
   status: status

--- a/config/install/migrate_plus.migration.directories_facets.yml
+++ b/config/install/migrate_plus.migration.directories_facets.yml
@@ -10,6 +10,7 @@ source:
   plugin: d8_entity
   entity_type: taxonomy_term
   bundle: directory_facet_option
+  track_changes: true
 process:
   bundle:
     -

--- a/config/install/migrate_plus.migration.directories_facets_type.yml
+++ b/config/install/migrate_plus.migration.directories_facets_type.yml
@@ -12,6 +12,7 @@ source:
   bundle: directory_facet
   constants:
     entity_type: directories_facets_type
+  track_changes: true
 process:
   entity_type: 'constants/entity_type'
   id:

--- a/config/install/migrate_plus.migration.directory_channel.yml
+++ b/config/install/migrate_plus.migration.directory_channel.yml
@@ -16,9 +16,9 @@ source:
     channel_types:
       - localgov_directories_page
       - localgov_directories_venue
+  track_changes: true
 process:
   nid: nid
-  vid: vid
   uuid: uuid
   uid: uid
   status: status

--- a/config/install/migrate_plus.migration.directory_page.yml
+++ b/config/install/migrate_plus.migration.directory_page.yml
@@ -11,6 +11,7 @@ source:
   entity_type: node
   bundle: directory_item
   include_translations: false
+  track_changes: true
 process:
   # Skip if geofield is set as this should be a localgov_directories_venue.
   location:
@@ -18,7 +19,6 @@ process:
     method: row
     source: field_geofield
   nid: nid
-  vid: vid
   uuid: uuid
   uid: uid
   status: status

--- a/config/install/migrate_plus.migration.directory_venue.yml
+++ b/config/install/migrate_plus.migration.directory_venue.yml
@@ -11,6 +11,7 @@ source:
   entity_type: node
   bundle: directory_item
   include_translations: false
+  track_changes: true
 process:
   # Skip if Geofield data is missing as this should be a localgov_directories_page.
   location:
@@ -18,7 +19,6 @@ process:
     index: 0
     source: field_geofield
   nid: nid
-  vid: vid
   uuid: uuid
   uid: uid
   status: status

--- a/config/install/migrate_plus.migration.files.yml
+++ b/config/install/migrate_plus.migration.files.yml
@@ -12,6 +12,7 @@ source:
     # Specify this in the sites settings.local.php file as:
     # $config['migrate_plus.migration.file']['source']['constants']['source_base_path'] = 'https://example.com';
     source_base_path: ''
+  track_changes: true
 process:
   fid: fid
   filename: filename

--- a/config/install/migrate_plus.migration.geo_address.yml
+++ b/config/install/migrate_plus.migration.geo_address.yml
@@ -10,6 +10,7 @@ source:
   plugin: d8_entity
   entity_type: node
   bundle: directory_item
+  track_changes: true
 process:
   # Process directory entries with Geofield data into LocalGov Geo address entities.
   location:

--- a/config/install/migrate_plus.migration.guides_overview.yml
+++ b/config/install/migrate_plus.migration.guides_overview.yml
@@ -11,9 +11,9 @@ source:
   entity_type: node
   bundle: guide_overview
   include_translations: false
+  track_changes: true
 process:
   nid: nid
-  vid: vid
   uuid: uuid
   uid: uid
   status: status

--- a/config/install/migrate_plus.migration.guides_page.yml
+++ b/config/install/migrate_plus.migration.guides_page.yml
@@ -11,9 +11,9 @@ source:
   entity_type: node
   bundle: guide_page
   include_translations: false
+  track_changes: true
 process:
   nid: nid
-  vid: vid
   uuid: uuid
   uid: uid
   status: status

--- a/config/install/migrate_plus.migration.localgov_redirect.yml
+++ b/config/install/migrate_plus.migration.localgov_redirect.yml
@@ -9,6 +9,7 @@ label: 'Redirects'
 source:
   plugin: d8_entity
   entity_type: redirect
+  track_changes: true
 process:
   created: created
   language: language

--- a/config/install/migrate_plus.migration.media_document.yml
+++ b/config/install/migrate_plus.migration.media_document.yml
@@ -9,6 +9,7 @@ label: 'Media - documents'
 source:
   plugin: d8_entity
   entity_type: file
+  track_changes: true
 process:
   # Skip anything that's an image.
   type:

--- a/config/install/migrate_plus.migration.media_existing.yml
+++ b/config/install/migrate_plus.migration.media_existing.yml
@@ -9,9 +9,9 @@ label: 'Media - existing'
 source:
   plugin: d8_entity
   entity_type: media
+  track_changes: true
 process:
   mid: mid
-  vid: vid
   status: status
   uid: uid
   uuid: uuid

--- a/config/install/migrate_plus.migration.media_image.yml
+++ b/config/install/migrate_plus.migration.media_image.yml
@@ -9,6 +9,7 @@ label: 'Media - images'
 source:
   plugin: d8_entity
   entity_type: file
+  track_changes: true
 process:
   # Skip anything that's not an image.
   type:

--- a/config/install/migrate_plus.migration.service_landing.yml
+++ b/config/install/migrate_plus.migration.service_landing.yml
@@ -11,9 +11,9 @@ source:
   entity_type: node
   bundle: service_hub
   include_translations: false
+  track_changes: true
 process:
   nid: nid
-  vid: vid
   uuid: uuid
   uid: uid
   status: status

--- a/config/install/migrate_plus.migration.service_page.yml
+++ b/config/install/migrate_plus.migration.service_page.yml
@@ -11,9 +11,9 @@ source:
   entity_type: node
   bundle: service_info
   include_translations: false
+  track_changes: true
 process:
   nid: nid
-  vid: vid
   uuid: uuid
   uid: uid
   status: status

--- a/config/install/migrate_plus.migration.service_status.yml
+++ b/config/install/migrate_plus.migration.service_status.yml
@@ -11,9 +11,9 @@ source:
   entity_type: node
   bundle: service_update_page
   include_translations: false
+  track_changes: true
 process:
   nid: nid
-  vid: vid
   uuid: uuid
   uid: uid
   status: status

--- a/config/install/migrate_plus.migration.service_sublanding.yml
+++ b/config/install/migrate_plus.migration.service_sublanding.yml
@@ -11,9 +11,9 @@ source:
   entity_type: node
   bundle: sub_hub
   include_translations: false
+  track_changes: true
 process:
   nid: nid
-  vid: vid
   uuid: uuid
   uid: uid
   status: status

--- a/config/install/migrate_plus.migration.step_by_step_overview.yml
+++ b/config/install/migrate_plus.migration.step_by_step_overview.yml
@@ -11,9 +11,9 @@ source:
   entity_type: node
   bundle: step_by_step_homepage
   include_translations: false
+  track_changes: true
 process:
   nid: nid
-  vid: vid
   uuid: uuid
   uid: uid
   status: status

--- a/config/install/migrate_plus.migration.step_by_step_page.yml
+++ b/config/install/migrate_plus.migration.step_by_step_page.yml
@@ -11,9 +11,9 @@ source:
   entity_type: node
   bundle: step_by_step_page
   include_translations: false
+  track_changes: true
 process:
   nid: nid
-  vid: vid
   uuid: uuid
   uid: uid
   status: status

--- a/config/install/migrate_plus.migration.topics.yml
+++ b/config/install/migrate_plus.migration.topics.yml
@@ -13,7 +13,6 @@ source:
   track_changes: true
 process:
   tid: tid
-  revision_id: revision_id
   uuid: uuid
   name: name
   # Disable pathauto for alias migration.

--- a/config/install/migrate_plus.migration.topics.yml
+++ b/config/install/migrate_plus.migration.topics.yml
@@ -10,6 +10,7 @@ source:
   plugin: d8_entity_path
   entity_type: taxonomy_term
   bundle: topic
+  track_changes: true
 process:
   tid: tid
   revision_id: revision_id

--- a/config/install/migrate_plus.migration.users.yml
+++ b/config/install/migrate_plus.migration.users.yml
@@ -7,6 +7,7 @@ label: 'User accounts'
 source:
   plugin: d8_entity
   entity_type: user
+  track_changes: true
 process:
   # Don't migrate user 0
   uid:


### PR DESCRIPTION
Once the initial migration is complete, subsequent migration runs should import newer changes made to the **source** entities.  This is not possible while we are explicitly migrating **revision ids**.  The error message says that the revision id for an existing entity cannot be updated.   To reproduce this, try ```drush migrate:import --update --group=localgov_migration``` on the **existing** code. To avoid this, I have dropped the "vid" and "revision_id" fields from various migrations.

Dropping revision ids from Paragraph migrations has its problem given that Entity reference revision fields migrated elsewhere are using the revision ids for Paragraphs.  It's not impossible to fix although not simple.  So this change is limited to non-Paragraph entities only.

Additionally, I have also added the [track_changes](https://www.drupal.org/docs/8/api/migrate-api/migrate-source-plugins/overview-of-migrate-source-plugins#track_changes) key to the non-Paragraph migration files so that updates are fetched during every migration run whether we ask for updates or not.  An alternative to using the *track_changes* key is to do ```drush migrate:import --update --group=localgov_migration```.  But that is slower compared to *track_changes* as all entities are updated regardless of any need to update them.

Special note for the *localgov_redirect* migration.  Updates of this fails however you do it.  To avoid it, I had to use the --sync (i.e. ```drush migrate:import --sync localgov_redirect```) option just for this one migration.