### PR TITLE
Subsite migration: Replace Campaign migration with Subsite migration

### DIFF
--- a/config/install/migrate_plus.migration.paragraph_box_link.yml
+++ b/config/install/migrate_plus.migration.paragraph_box_link.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies:
   module:
-    - localgov_campaigns_paragraphs
+    - localgov_subsites_paragraphs
 id: paragraph_box_link
 migration_group: localgov_migration
 label: 'Paragraph - box link'

--- a/config/install/migrate_plus.migration.paragraph_call_out_box.yml
+++ b/config/install/migrate_plus.migration.paragraph_call_out_box.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies:
   module:
-    - localgov_campaigns_paragraphs
+    - localgov_subsites_paragraphs
 id: paragraph_call_out_box
 migration_group: localgov_migration
 label: 'Paragraph - call out box'

--- a/config/install/migrate_plus.migration.paragraph_fact_box.yml
+++ b/config/install/migrate_plus.migration.paragraph_fact_box.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies:
   module:
-    - localgov_campaigns_paragraphs
+    - localgov_subsites_paragraphs
 id: paragraph_fact_box
 migration_group: localgov_migration
 label: 'Paragraph - fact box'

--- a/config/install/migrate_plus.migration.paragraph_link.yml
+++ b/config/install/migrate_plus.migration.paragraph_link.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies:
   module:
-    - localgov_campaigns_paragraphs
+    - localgov_subsites_paragraphs
 id: paragraph_link
 migration_group: localgov_migration
 label: 'Paragraph - link'

--- a/config/install/migrate_plus.migration.paragraph_link_and_summary.yml
+++ b/config/install/migrate_plus.migration.paragraph_link_and_summary.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies:
   module:
-    - localgov_campaigns_paragraphs
+    - localgov_subsites_paragraphs
 id: paragraph_link_and_summary
 migration_group: localgov_migration
 label: 'Paragraph - link and summary'

--- a/config/install/migrate_plus.migration.paragraph_quote.yml
+++ b/config/install/migrate_plus.migration.paragraph_quote.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies:
   module:
-    - localgov_campaigns_paragraphs
+    - localgov_subsites_paragraphs
 id: paragraph_quote
 migration_group: localgov_migration
 label: 'Paragraph - call out box'

--- a/config/install/migrate_plus.migration.paragraph_text.yml
+++ b/config/install/migrate_plus.migration.paragraph_text.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies:
   module:
-    - localgov_campaigns_paragraphs
+    - localgov_subsites_paragraphs
 id: paragraph_text
 migration_group: localgov_migration
 label: 'Paragraph - call out box'

--- a/config/install/migrate_plus.migration.subsites_overview.yml
+++ b/config/install/migrate_plus.migration.subsites_overview.yml
@@ -2,10 +2,10 @@ langcode: en
 status: true
 dependencies:
   module:
-    - localgov_guides
-id: campaigns_overview
+    - localgov_subsites
+id: subsites_overview
 migration_group: localgov_migration
-label: 'Campaigns - overview'
+label: 'Subsites - overview'
 source:
   plugin: d8_entity
   entity_type: node
@@ -21,18 +21,11 @@ process:
   changed: changed
   comment: comment
   title: title
-  localgov_campaigns_banner_image:
-    plugin: entity_ref_lookup
-    migration: media_image
-    source: field_banner
-  localgov_campaigns_pages: field_campaign_pages
-  localgov_campaigns_hide_menu: field_hide_sidebar
-  localgov_campaigns_content:
+  localgov_subsites_hide_menu: field_hide_sidebar
+  localgov_subsites_content:
     plugin: layout_paragraphs
     source: field_page_builder_advanced
-  localgov_campaigns_colour_accent: field_select_colourway_accent
-  localgov_campaigns_colour_grad: field_select_colorway
-  localgov_campaigns_summary: 'body/summary'
+  localgov_subsites_summary: 'body/summary'
   # Workflow content moderation state.
   moderation_state: moderation_state
   # Alternative Workflow content moderation state.
@@ -48,7 +41,7 @@ process:
   #       '1': published
 destination:
   plugin: 'entity:node'
-  default_bundle: localgov_campaigns_overview
+  default_bundle: localgov_subsites_overview
 migration_dependencies:
   required:
     - media_image

--- a/config/install/migrate_plus.migration.subsites_page.yml
+++ b/config/install/migrate_plus.migration.subsites_page.yml
@@ -2,10 +2,10 @@ langcode: en
 status: true
 dependencies:
   module:
-    - localgov_guides
-id: campaigns_page
+    - localgov_subsites
+id: subsites_page
 migration_group: localgov_migration
-label: 'Campaigns - page'
+label: 'Subsites - page'
 source:
   plugin: d8_entity
   entity_type: node
@@ -21,12 +21,12 @@ process:
   changed: changed
   comment: comment
   title: title
-  localgov_campaigns_parent: field_campaign
-  localgov_campaigns_content:
+  localgov_subsites_parent: field_campaign
+  localgov_subsites_content:
     plugin: layout_paragraphs
     source: field_page_builder_advanced
-  localgov_campaigns_summary: 'body/summary'
-  localgov_campaigns_topic: field_topic_term
+  localgov_subsites_summary: 'body/summary'
+  localgov_subsites_topic: field_topic_term
   # Workflow content moderation state.
   moderation_state: moderation_state
   # Alternative Workflow content moderation state.
@@ -42,10 +42,10 @@ process:
   #       '1': published
 destination:
   plugin: 'entity:node'
-  default_bundle: localgov_campaigns_page
+  default_bundle: localgov_subsites_page
 migration_dependencies:
   required:
-    - campaigns_overview
+    - subsites_overview
     - media_image
   optional:
     - paragraph_box_link

--- a/localgov_legacy_migration.info.yml
+++ b/localgov_legacy_migration.info.yml
@@ -11,8 +11,8 @@ dependencies:
   - redirect:redirect
   # LocalGov Drupal
   - localgov_core:localgov_media
-  - localgov_campaigns:localgov_campaigns
-  - localgov_campaigns:localgov_campaigns_paragraphs
+  - localgov_subsites:localgov_subsites
+  - localgov_subsites:localgov_subsites_paragraphs
   - localgov_directories:localgov_directories
   - localgov_directories:localgov_directories_page
   - localgov_directories:localgov_directories_venue

--- a/src/Plugin/migrate/process/LayoutParagraphs.php
+++ b/src/Plugin/migrate/process/LayoutParagraphs.php
@@ -17,7 +17,7 @@ use PDO;
  * )
  *
  * @code
- * localgov_campaigns_content:
+ * localgov_subsites_content:
  *   plugin: layout_paragraphs
  *   source: field_page_builder_advanced
  * @endcode


### PR DESCRIPTION
At the moment, this only works on a LocalGov site where the localgov_campaigns_paragraphs submodule has **never** been installed.

Closes #26 